### PR TITLE
import ScrollView from react-navigation

### DIFF
--- a/lib/KeyboardAwareScrollView.js
+++ b/lib/KeyboardAwareScrollView.js
@@ -1,6 +1,6 @@
 /* @flow */
 
-import { ScrollView } from 'react-native'
+import { ScrollView } from 'react-navigation'
 import listenToKeyboardEvents from './KeyboardAwareHOC'
 
 export default listenToKeyboardEvents(ScrollView)

--- a/package.json
+++ b/package.json
@@ -37,7 +37,8 @@
   "homepage": "https://github.com/APSL/react-native-keyboard-aware-scroll-view#readme",
   "dependencies": {
     "prop-types": "^15.6.2",
-    "react-native-iphone-x-helper": "^1.0.3"
+    "react-native-iphone-x-helper": "^1.0.3",
+    "react-navigation": "^4.3.7"
   },
   "peerDependencies": {
     "react-native": ">=0.48.4"


### PR DESCRIPTION
This is a branch which uses ScrollView from react-navigation instead of react-native.
It allows to scrollToTop when navigation bar was pressed.